### PR TITLE
Add arguments for failure behavior during file input

### DIFF
--- a/shell/src/main/java/org/neo4j/shell/CliArgHelper.java
+++ b/shell/src/main/java/org/neo4j/shell/CliArgHelper.java
@@ -1,19 +1,28 @@
 package org.neo4j.shell;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
-import net.sourceforge.argparse4j.inf.ArgumentParser;
-import net.sourceforge.argparse4j.inf.ArgumentParserException;
-import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.impl.action.StoreConstArgumentAction;
+import net.sourceforge.argparse4j.inf.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.neo4j.shell.CliArgHelper.FailBehavior.FAIL_AT_END;
+import static org.neo4j.shell.CliArgHelper.FailBehavior.FAIL_FAST;
+
 /**
  * Command line argument parsing and related stuff
  */
 public class CliArgHelper {
+
+    public enum FailBehavior {
+        FAIL_FAST,
+        FAIL_AT_END
+    }
+
+
     public static final Pattern addressArgPattern =
             Pattern.compile("\\s*((?<username>\\w+):(?<password>[^\\s]+)@)?(?<host>[\\d\\.\\w]+)?(:(?<port>\\d+))?\\s*");
 
@@ -23,15 +32,29 @@ public class CliArgHelper {
                                                .defaultHelp(true)
                                                .description("A command line shell where you can execute Cypher against an instance of Neo4j");
 
-        parser.addArgument("-a", "--address")
+        ArgumentGroup connGroup = parser.addArgumentGroup("connection arguments");
+        connGroup.addArgument("-a", "--address")
                 .help("Address and port to connect to")
                 .setDefault("localhost:7687");
-        parser.addArgument("-u", "--username")
-              .setDefault("")
+        connGroup.addArgument("-u", "--username")
+                .setDefault("")
                 .help("Username to connect as");
-        parser.addArgument("-p", "--password")
-              .setDefault("")
+        connGroup.addArgument("-p", "--password")
+                .setDefault("")
                 .help("Password to connect with");
+
+        MutuallyExclusiveGroup failGroup = parser.addMutuallyExclusiveGroup();
+        failGroup.addArgument("-ff", "--fail-fast")
+                .help("Exit and report failure on first error when reading from file")
+                .dest("fail-behavior")
+                .setConst(FAIL_FAST)
+                .action(new StoreConstArgumentAction());
+        failGroup.addArgument("-fae", "--fail-at-end")
+                .help("Exit and report failures at end of input when reading from file")
+                .dest("fail-behavior")
+                .setConst(FAIL_AT_END)
+                .action(new StoreConstArgumentAction());
+        parser.setDefault("fail-behavior", FAIL_FAST);
 
         Namespace ns = null;
         try {
@@ -53,23 +76,27 @@ public class CliArgHelper {
             System.exit(1);
         }
 
-        cliArgs.host(m.group("host"), "localhost");
+        cliArgs.setHost(m.group("host"), "localhost");
         // Safe, regex only matches integers
         String portString = m.group("port");
-        cliArgs.port(portString == null ? 7687 : Integer.parseInt(portString));
+        cliArgs.setPort(portString == null ? 7687 : Integer.parseInt(portString));
         // Also parse username and password from address if available
-        cliArgs.username(m.group("username"), "");
-        cliArgs.password(m.group("password"), "");
+        cliArgs.setUsername(m.group("username"), "");
+        cliArgs.setPassword(m.group("password"), "");
 
         // Only overwrite user/pass from address string if the arguments were specified
         String user = ns.getString("username");
         if (!user.isEmpty()) {
-            cliArgs.username(user, cliArgs.username);
+            cliArgs.setUsername(user, cliArgs.username);
         }
         String pass = ns.getString("password");
         if (!pass.isEmpty()) {
-            cliArgs.password(pass, cliArgs.password);
+            cliArgs.setPassword(pass, cliArgs.password);
         }
+
+        // Other arguments
+        // Fail behavior as sensible default and returns a proper type
+        cliArgs.setFailBehavior(ns.get("fail-behavior"));
 
         return cliArgs;
     }
@@ -81,53 +108,62 @@ public class CliArgHelper {
         private int port = 7687;
         private String username = "";
         private String password = "";
+        private FailBehavior failBehavior = FailBehavior.FAIL_FAST;
 
-        public boolean suppressColor() {
+        public boolean getSuppressColor() {
             return suppressColor;
         }
 
         /**
          * Set the host to the primary value, or if null, the fallback value.
          */
-        void host(@Nullable String primary, @Nonnull String fallback) {
+        void setHost(@Nullable String primary, @Nonnull String fallback) {
             host = primary == null ? fallback : primary;
         }
 
         /**
          * Set the port to the value.
          */
-        void port(int port) {
+        void setPort(int port) {
             this.port = port;
         }
 
         /**
          * Set the username to the primary value, or if null, the fallback value.
          */
-        void username(@Nullable String primary, @Nonnull String fallback) {
+        void setUsername(@Nullable String primary, @Nonnull String fallback) {
             username = primary == null ? fallback : primary;
         }
 
         /**
          * Set the password to the primary value, or if null, the fallback value.
          */
-        void password(@Nullable String primary, @Nonnull String fallback) {
+        void setPassword(@Nullable String primary, @Nonnull String fallback) {
             password = primary == null ? fallback : primary;
         }
 
-        public String host() {
+        void setFailBehavior(FailBehavior failBehavior) {
+            this.failBehavior = failBehavior;
+        }
+
+        public String getHost() {
             return host;
         }
 
-        public int port() {
+        public int getPort() {
             return port;
         }
 
-        public String username() {
+        public String getUsername() {
             return username;
         }
 
-        public String password() {
+        public String getPassword() {
             return password;
+        }
+
+        public FailBehavior getFailBehavior() {
+            return failBehavior;
         }
     }
 

--- a/shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -40,13 +40,13 @@ public class CypherShell extends Shell {
         commandHelper = new CommandHelper(this);
     }
 
-    int run() {
+    int run(@Nonnull CliArgHelper.CliArgs cliArgs) {
         int exitCode;
 
         try {
             connect(host, port, username, password);
 
-            runner = getShellRunner();
+            runner = getShellRunner(cliArgs);
             runner.run();
 
             exitCode = 0;

--- a/shell/src/main/java/org/neo4j/shell/InteractiveShellRunner.java
+++ b/shell/src/main/java/org/neo4j/shell/InteractiveShellRunner.java
@@ -103,7 +103,7 @@ public class InteractiveShellRunner extends ShellRunner {
         }
 
         if (!line.trim().isEmpty()) {
-            shell.execute(line);
+            shell.executeLine(line);
         }
 
         return true;

--- a/shell/src/main/java/org/neo4j/shell/Main.java
+++ b/shell/src/main/java/org/neo4j/shell/Main.java
@@ -2,6 +2,8 @@ package org.neo4j.shell;
 
 import org.fusesource.jansi.AnsiConsole;
 
+import javax.annotation.Nonnull;
+
 public class Main {
 
     public static void main(String[] args) {
@@ -19,11 +21,11 @@ public class Main {
         }
     }
 
-    private void startShell(CliArgHelper.CliArgs cliArgs) {
+    private void startShell(@Nonnull CliArgHelper.CliArgs cliArgs) {
         CypherShell shell = new CypherShell(cliArgs.getHost(), cliArgs.getPort(),
                 cliArgs.getUsername(), cliArgs.getPassword());
 
-        int code = shell.run();
+        int code = shell.run(cliArgs);
 
         System.exit(code);
     }

--- a/shell/src/main/java/org/neo4j/shell/Main.java
+++ b/shell/src/main/java/org/neo4j/shell/Main.java
@@ -7,7 +7,7 @@ public class Main {
     public static void main(String[] args) {
         CliArgHelper.CliArgs cliArgs = CliArgHelper.parse(args);
 
-        configureTerminal(cliArgs.suppressColor());
+        configureTerminal(cliArgs.getSuppressColor());
 
         Main main = new Main();
         main.startShell(cliArgs);
@@ -20,7 +20,7 @@ public class Main {
     }
 
     private void startShell(CliArgHelper.CliArgs cliArgs) {
-        CypherShell shell = new CypherShell(cliArgs.host(), cliArgs.port(), cliArgs.username(), cliArgs.password());
+        CypherShell shell = new CypherShell(cliArgs.getHost(), cliArgs.getPort(), cliArgs.getUsername(), cliArgs.getPassword());
 
         // TODO: 6/21/16 Shutdown hook for recording history
 

--- a/shell/src/main/java/org/neo4j/shell/Main.java
+++ b/shell/src/main/java/org/neo4j/shell/Main.java
@@ -20,9 +20,8 @@ public class Main {
     }
 
     private void startShell(CliArgHelper.CliArgs cliArgs) {
-        CypherShell shell = new CypherShell(cliArgs.getHost(), cliArgs.getPort(), cliArgs.getUsername(), cliArgs.getPassword());
-
-        // TODO: 6/21/16 Shutdown hook for recording history
+        CypherShell shell = new CypherShell(cliArgs.getHost(), cliArgs.getPort(),
+                cliArgs.getUsername(), cliArgs.getPassword());
 
         int code = shell.run();
 

--- a/shell/src/main/java/org/neo4j/shell/NonInteractiveShellRunner.java
+++ b/shell/src/main/java/org/neo4j/shell/NonInteractiveShellRunner.java
@@ -2,6 +2,7 @@ package org.neo4j.shell;
 
 import jline.console.ConsoleReader;
 import jline.console.history.History;
+import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.shell.commands.Exit;
 
 import javax.annotation.Nonnull;
@@ -15,11 +16,13 @@ public class NonInteractiveShellRunner extends ShellRunner {
 
     private final Shell shell;
     private final ConsoleReader reader;
+    private final CliArgHelper.FailBehavior failBehavior;
 
-    public NonInteractiveShellRunner(@Nonnull Shell shell) throws IOException {
+    public NonInteractiveShellRunner(@Nonnull Shell shell, @Nonnull CliArgHelper.CliArgs cliArgs) throws IOException {
         super();
+        failBehavior = cliArgs.getFailBehavior();
         this.shell = shell;
-        this.reader = new ConsoleReader();
+        reader = new ConsoleReader();
     }
 
     @Override
@@ -41,9 +44,19 @@ public class NonInteractiveShellRunner extends ShellRunner {
             } catch (Exit.ExitException e) {
                 // These exceptions are always fatal
                 throw e;
-            } catch (CommandException e) {
-                // TODO: 6/29/16 let a flag control if we should exit directly on errors or keep going
-                throw e;
+            } catch (ClientException e) {
+                if (CliArgHelper.FailBehavior.FAIL_AT_END == failBehavior) {
+                    shell.printError(BoltHelper.getSensibleMsg(e));
+                } else {
+                    throw e;
+                }
+            }
+            catch (Throwable t) {
+                if (CliArgHelper.FailBehavior.FAIL_AT_END == failBehavior) {
+                    shell.printError(t.getMessage());
+                } else {
+                    throw t;
+                }
             }
         }
     }

--- a/shell/src/main/java/org/neo4j/shell/NonInteractiveShellRunner.java
+++ b/shell/src/main/java/org/neo4j/shell/NonInteractiveShellRunner.java
@@ -10,7 +10,8 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
- * A shell runner which reads from STDIN and executes commands until completion.
+ * A shell runner which reads from STDIN and executes commands until completion. In case of errors, the failBehavior
+ * determines if the shell exits immediately, or if it should keep trying the next commands.
  */
 public class NonInteractiveShellRunner extends ShellRunner {
 
@@ -22,7 +23,7 @@ public class NonInteractiveShellRunner extends ShellRunner {
         super();
         failBehavior = cliArgs.getFailBehavior();
         this.shell = shell;
-        reader = new ConsoleReader();
+        reader = new ConsoleReader(shell.getInputStream(), shell.getOutputStream());
     }
 
     @Override

--- a/shell/src/main/java/org/neo4j/shell/NonInteractiveShellRunner.java
+++ b/shell/src/main/java/org/neo4j/shell/NonInteractiveShellRunner.java
@@ -41,7 +41,7 @@ public class NonInteractiveShellRunner extends ShellRunner {
                 }
 
                 if (!line.trim().isEmpty()) {
-                    shell.execute(line);
+                    shell.executeLine(line);
                 }
             } catch (Exit.ExitException e) {
                 // These exceptions are always fatal

--- a/shell/src/main/java/org/neo4j/shell/NonInteractiveShellRunner.java
+++ b/shell/src/main/java/org/neo4j/shell/NonInteractiveShellRunner.java
@@ -29,6 +29,7 @@ public class NonInteractiveShellRunner extends ShellRunner {
     public void run() throws CommandException, IOException {
         String line;
         boolean running = true;
+        boolean errorOccurred = false;
         while (running) {
             line = reader.readLine();
 
@@ -45,6 +46,7 @@ public class NonInteractiveShellRunner extends ShellRunner {
                 // These exceptions are always fatal
                 throw e;
             } catch (ClientException e) {
+                errorOccurred = true;
                 if (CliArgHelper.FailBehavior.FAIL_AT_END == failBehavior) {
                     shell.printError(BoltHelper.getSensibleMsg(e));
                 } else {
@@ -52,12 +54,18 @@ public class NonInteractiveShellRunner extends ShellRunner {
                 }
             }
             catch (Throwable t) {
+                errorOccurred = true;
                 if (CliArgHelper.FailBehavior.FAIL_AT_END == failBehavior) {
                     shell.printError(t.getMessage());
                 } else {
                     throw t;
                 }
             }
+        }
+
+        // End of input, in case of error, set correct exit code
+        if (errorOccurred) {
+            throw new Exit.ExitException(1);
         }
     }
 

--- a/shell/src/main/java/org/neo4j/shell/Shell.java
+++ b/shell/src/main/java/org/neo4j/shell/Shell.java
@@ -37,11 +37,11 @@ abstract public class Shell {
         return 1 == isatty(STDIN_FILENO);
     }
 
-    ShellRunner getShellRunner() throws IOException {
+    ShellRunner getShellRunner(@Nonnull CliArgHelper.CliArgs cliArgs) throws IOException {
         if (isInteractive()) {
             return new InteractiveShellRunner(this);
         } else {
-            return new NonInteractiveShellRunner(this);
+            return new NonInteractiveShellRunner(this, cliArgs);
         }
     }
 

--- a/shell/src/main/java/org/neo4j/shell/Shell.java
+++ b/shell/src/main/java/org/neo4j/shell/Shell.java
@@ -5,6 +5,8 @@ import org.neo4j.shell.commands.Exit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
 
 import static org.fusesource.jansi.Ansi.ansi;
 import static org.fusesource.jansi.internal.CLibrary.STDIN_FILENO;
@@ -15,12 +17,26 @@ import static org.fusesource.jansi.internal.CLibrary.isatty;
  */
 abstract public class Shell {
 
+    protected InputStream in = System.in;
+    protected PrintStream out = System.out;
+    protected PrintStream err = System.err;
+
     public void printOut(@Nonnull final String msg) {
-        System.out.println(ansi().render(msg));
+        out.println(ansi().render(msg));
     }
 
     public void printError(@Nonnull final String msg) {
-        System.err.println(ansi().render(msg));
+        err.println(ansi().render(msg));
+    }
+
+    @Nonnull
+    public InputStream getInputStream() {
+        return in;
+    }
+
+    @Nonnull
+    public PrintStream getOutputStream() {
+        return out;
     }
 
     @Nonnull
@@ -46,4 +62,5 @@ abstract public class Shell {
     }
 
     abstract public void execute(@Nonnull String line) throws Exit.ExitException, CommandException;
+
 }

--- a/shell/src/main/java/org/neo4j/shell/Shell.java
+++ b/shell/src/main/java/org/neo4j/shell/Shell.java
@@ -61,6 +61,12 @@ abstract public class Shell {
         }
     }
 
-    abstract public void execute(@Nonnull String line) throws Exit.ExitException, CommandException;
+    /**
+     * Handle a single line of input. If this is a part of a multi-line statement, it should be handled accordingly.
+     * Otherwise it is expected to be executed immediately.
+     *
+     * @param line single line of input
+     */
+    abstract public void executeLine(@Nonnull String line) throws Exit.ExitException, CommandException;
 
 }

--- a/shell/src/main/java/org/neo4j/shell/commands/Exit.java
+++ b/shell/src/main/java/org/neo4j/shell/commands/Exit.java
@@ -55,7 +55,7 @@ public class Exit implements Command {
         throw new ExitException(0);
     }
 
-    public class ExitException extends Error {
+    public static class ExitException extends Error {
         private final int code;
 
         public ExitException(int code) {

--- a/shell/src/test/java/org/neo4j/shell/CliArgHelperTest.java
+++ b/shell/src/test/java/org/neo4j/shell/CliArgHelperTest.java
@@ -3,32 +3,29 @@ package org.neo4j.shell;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.neo4j.shell.Util.asArray;
 
 public class CliArgHelperTest {
 
     @Test
     public void testFailFastIsDefault() {
         assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_FAST,
-                CliArgHelper.parse(args()).getFailBehavior());
+                CliArgHelper.parse(asArray()).getFailBehavior());
     }
 
     @Test
     public void testFailFastIsParsed() {
         assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_FAST,
-                CliArgHelper.parse(args("-ff")).getFailBehavior());
+                CliArgHelper.parse(asArray("-ff")).getFailBehavior());
         assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_FAST,
-                CliArgHelper.parse(args("--fail-fast")).getFailBehavior());
+                CliArgHelper.parse(asArray("--fail-fast")).getFailBehavior());
     }
 
     @Test
     public void testFailAtEndIsParsed() {
         assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_AT_END,
-                CliArgHelper.parse(args("-fae")).getFailBehavior());
+                CliArgHelper.parse(asArray("-fae")).getFailBehavior());
         assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_AT_END,
-                CliArgHelper.parse(args("--fail-at-end")).getFailBehavior());
-    }
-
-    private String[] args(String... arguments) {
-        return arguments;
+                CliArgHelper.parse(asArray("--fail-at-end")).getFailBehavior());
     }
 }

--- a/shell/src/test/java/org/neo4j/shell/CliArgHelperTest.java
+++ b/shell/src/test/java/org/neo4j/shell/CliArgHelperTest.java
@@ -1,0 +1,34 @@
+package org.neo4j.shell;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CliArgHelperTest {
+
+    @Test
+    public void testFailFastIsDefault() {
+        assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_FAST,
+                CliArgHelper.parse(args()).getFailBehavior());
+    }
+
+    @Test
+    public void testFailFastIsParsed() {
+        assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_FAST,
+                CliArgHelper.parse(args("-ff")).getFailBehavior());
+        assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_FAST,
+                CliArgHelper.parse(args("--fail-fast")).getFailBehavior());
+    }
+
+    @Test
+    public void testFailAtEndIsParsed() {
+        assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_AT_END,
+                CliArgHelper.parse(args("-fae")).getFailBehavior());
+        assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_AT_END,
+                CliArgHelper.parse(args("--fail-at-end")).getFailBehavior());
+    }
+
+    private String[] args(String... arguments) {
+        return arguments;
+    }
+}

--- a/shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -1,0 +1,56 @@
+package org.neo4j.shell;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+
+public class CypherShellTest {
+    private CypherTestShell shell;
+
+    @Before
+    public void setup() {
+        shell = new CypherTestShell();
+    }
+
+    @Test
+    public void commentsShouldNotBeExecuted() throws Exception {
+        shell.executeLine("// Hi, I'm a comment!");
+        // If no exception was thrown, we have success
+    }
+
+    @Test
+    public void emptyLinesShouldNotBeExecuted() throws Exception {
+        shell.executeLine("");
+        // If no exception was thrown, we have success
+    }
+
+    class CypherTestShell extends CypherShell {
+
+        CypherTestShell() {
+            super("", 1, "", "");
+        }
+
+        @Override
+        void executeCypher(@Nonnull String line) {
+            throw new RuntimeException("Unexpected cypher execution");
+        }
+
+        @Override
+        public void connect(@Nonnull String host, int port,
+                            @Nonnull String username, @Nonnull String password) throws CommandException {
+            throw new RuntimeException("Test shell can't connect");
+        }
+
+        @Override
+        public void disconnect() throws CommandException {
+            throw new RuntimeException("Test shell can't disconnect");
+        }
+
+        @Override
+        boolean isConnected() {
+            return true;
+        }
+    }
+}

--- a/shell/src/test/java/org/neo4j/shell/NonInteractiveShellRunnerTest.java
+++ b/shell/src/test/java/org/neo4j/shell/NonInteractiveShellRunnerTest.java
@@ -1,0 +1,104 @@
+package org.neo4j.shell;
+
+import org.junit.Test;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.shell.commands.Exit;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.shell.Util.asArray;
+
+public class NonInteractiveShellRunnerTest {
+
+    @Test
+    public void testSimple() throws Exception {
+        TestShell shell = new TestShell(
+                "good1\n" +
+                        "good2\n");
+        NonInteractiveShellRunner runner = new NonInteractiveShellRunner(shell, CliArgHelper.parse(asArray("-ff")));
+        runner.run();
+    }
+
+    @Test
+    public void testFailFast() throws Exception {
+        TestShell shell = new TestShell(
+                "good1\n" +
+                        "bad\n" +
+                        "good2\n");
+        NonInteractiveShellRunner runner = new NonInteractiveShellRunner(shell, CliArgHelper.parse(asArray("-ff")));
+        try {
+            runner.run();
+            fail("Expected an exception to be thrown");
+        } catch (ClientException e) {
+            assertEquals(e.getMessage(), "Found a bad line");
+        }
+    }
+
+    @Test
+    public void testFailAtEnd() throws Exception {
+        final String input =  "good1\n" +
+                "bad\n" +
+                "good2\n";
+        final String expectedOut =  "good1\nSuccess\n" +
+                "bad\n" +
+                "good2\nSuccess\n";
+        TestShell shell = new TestShell(input);
+        NonInteractiveShellRunner runner = new NonInteractiveShellRunner(shell, CliArgHelper.parse(asArray("-fae")));
+        try {
+            runner.run();
+            fail("Expected an exit code to be set");
+        } catch (Exit.ExitException e) {
+            assertEquals("Wrong exit code", 1, e.getCode());
+            assertEquals("Incorrect STDERR", "Found a bad line\n", shell.getErrLog());
+            assertEquals("Incorrect STDOUT", expectedOut, shell.getOutLog().replaceAll("\r", ""));
+        }
+    }
+
+    private class TestShell extends Shell {
+        private final ByteArrayOutputStream errStream;
+        private final ByteArrayOutputStream outStream;
+
+        TestShell(@Nonnull final String input) {
+            in = new ByteArrayInputStream(input.getBytes());
+            errStream = new java.io.ByteArrayOutputStream();
+            err = new PrintStream(errStream);
+            outStream = new ByteArrayOutputStream();
+            out = new PrintStream(outStream);
+        }
+
+        @Nonnull
+        @Override
+        public String prompt() {
+            return "";
+        }
+
+        @Nullable
+        @Override
+        public Character promptMask() {
+            return null;
+        }
+
+        @Override
+        public void execute(@Nonnull String line) throws Exit.ExitException, CommandException {
+            if (line.contains("bad")) {
+                throw new ClientException("Found a bad line");
+            } else {
+                printOut("Success");
+            }
+        }
+
+        public String getOutLog() {
+            return outStream.toString();
+        }
+
+        public String getErrLog() {
+            return errStream.toString();
+        }
+    }
+}

--- a/shell/src/test/java/org/neo4j/shell/NonInteractiveShellRunnerTest.java
+++ b/shell/src/test/java/org/neo4j/shell/NonInteractiveShellRunnerTest.java
@@ -85,7 +85,7 @@ public class NonInteractiveShellRunnerTest {
         }
 
         @Override
-        public void execute(@Nonnull String line) throws Exit.ExitException, CommandException {
+        public void executeLine(@Nonnull String line) throws Exit.ExitException, CommandException {
             if (line.contains("bad")) {
                 throw new ClientException("Found a bad line");
             } else {

--- a/shell/src/test/java/org/neo4j/shell/Util.java
+++ b/shell/src/test/java/org/neo4j/shell/Util.java
@@ -1,0 +1,7 @@
+package org.neo4j.shell;
+
+public class Util {
+    static String[] asArray(String... arguments) {
+        return arguments;
+    }
+}


### PR DESCRIPTION
New arguments, so here is the updated help text:

```
usage: neo4j-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD] [-ff | -fae]

A command line shell where you can execute Cypher against an instance of Neo4j

optional arguments:
  -h, --help             show this help message and exit
  -ff, --fail-fast       Exit and report failure on first error when reading from file
  -fae, --fail-at-end    Exit and report failures at end of input when reading from file

connection arguments:
  -a ADDRESS, --address ADDRESS
                         Address and port to connect to (default: localhost:7687)
  -u USERNAME, --username USERNAME
                         Username to connect as (default: )
  -p PASSWORD, --password PASSWORD
                         Password to connect with (default: )
```

Those two new arguments (`ff` and `fae`) are mutually exclusive. If a user specifies both of them, the shell will complain:

`shell/build/install/shell/bin/shell -ff -fae`

```
usage: neo4j-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD] [-ff | -fae]
neo4j-shell: error: argument -fae/--fail-at-end: not allowed with argument -ff/--fail-fast
```

## Example invocations and results in STDOUT

Using the following `errors.cql` with typo on second line:

```
CREATE (n:Person {name: "Jonas"}) RETURN n
CREATE (n) RETRN n
MATCH (n:Person) RETURN n
```

### Fail fast (default behavior)

`cat errors.cql | shell/build/install/shell/bin/shell -ff`

```
CREATE (n:Person {name: "Jonas"}) RETURN n
n
{name: "Jonas"}

CREATE (n) RETRN n
Invalid input 'R': expected 'u/U' (line 1, column 15 (offset: 14))
"CREATE (n) RETRN n"
               ^
```

### Fail at end

`cat errors.cql | shell/build/install/shell/bin/shell -fae`

```
CREATE (n:Person {name: "Jonas"}) RETURN n
n
{name: "Jonas"}

CREATE (n) RETRN n
Invalid input 'R': expected 'u/U' (line 1, column 15 (offset: 14))
"CREATE (n) RETRN n"
               ^

MATCH (n:Person) RETURN n
n
{name: "Jonas"}
{name: "Jonas"}
{name: "Jonas"}
{name: "Jonas"}
{name: "Jonas"}
{name: "Jonas"}
```
